### PR TITLE
Enable edge creation from node handles

### DIFF
--- a/cytoscape-edgehandles.d.ts
+++ b/cytoscape-edgehandles.d.ts
@@ -1,0 +1,2 @@
+declare module 'cytoscape-edgehandles';
+declare module 'react-cytoscapejs';


### PR DESCRIPTION
## Summary
- Enable Cytoscape edgehandles and allow dragging handles onto empty space to spawn and link a new node
- Add module declarations for `cytoscape-edgehandles` and `react-cytoscapejs`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interactive ESLint configuration prompt)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689e8357e89c8321a920232544b6ea56